### PR TITLE
Creates `singleClass` to set <span> class

### DIFF
--- a/packages/reporter-dom/src/index.ts
+++ b/packages/reporter-dom/src/index.ts
@@ -9,6 +9,7 @@ import type {
 export interface DomReporterOptions {
   listType?: 'ul' | 'ol';
   single?: boolean;
+  singleClass?: string;
 }
 
 const mutationConfig: MutationObserverInit = {
@@ -24,7 +25,7 @@ function removeAllChildren(parent: Node): void {
 
 function setValidationMessage(
   target: FormControl,
-  { listType = 'ul', single }: DomReporterOptions
+  { listType = 'ul', single, singleClass = '' }: DomReporterOptions
 ) {
   if (!target.name || !target.id) return;
   const validationMessage = target.dataset.felteValidationMessage;
@@ -52,6 +53,7 @@ function setValidationMessage(
     spanElement.dataset.felteReporterDomSingleMessage = '';
     const textNode = document.createTextNode(validationMessage);
     spanElement.appendChild(textNode);
+    spanElement.classList.add(singleClass);
     reporterElement.appendChild(spanElement);
   }
   if (reportAsList) {


### PR DESCRIPTION
As a [Tailwind CSS](https://tailwindcss.com/) user I always try to declare classes to an element using `class=""` instead of doing by by `<style>` tag. That's important to keep our final bundled CSS file as little as it can be.

Using Felte with `@felte/reporter-dom` I can't declare the classes of the `<span>` created inside the main `<div>`. The only option, [as described in README](https://github.com/pablo-abc/felte/blob/main/packages/reporter-dom/README.md#styling), is using the CSS selector `[data-felte-reporter-dom-single-message]`.

This PR creates the option `singleClass`, that attach classes to the `<span>` element.

### How to use
```js
extend: [
   reporter({
      single: true,
      singleClass: 'bg-red-600 text-white inline-block py-1 px-2 rounded'
   })
],
```

### DOM
```html
<div id="name-validation" data-felte-reporter-dom-for="name">
   <span 
       class="bg-red-600 text-white inline-block py-1 px-2 rounded"
       aria-live="polite"
       data-felte-reporter-dom-single-message=""
   >
      Required field
   </span>
</div>
```

---

Ps: new to Typescript here. To be honest, I don't even know how to compile it. Help, please? 😅