### PR TITLE
Allow defining CSS classes for dynamic created elements

### DIFF
--- a/.changeset/big-carrots-clean.md
+++ b/.changeset/big-carrots-clean.md
@@ -1,0 +1,5 @@
+---
+'@felte/reporter-dom': minor
+---
+
+Allow defining CSS classes for dynamic created elements

--- a/packages/reporter-dom/src/index.ts
+++ b/packages/reporter-dom/src/index.ts
@@ -12,7 +12,9 @@ export interface DomReporterOptions {
   listType?: 'ul' | 'ol';
   listAttributes?: {
     class?: string | string[];
-    itemClass?: string | string[];
+  };
+  listItemAttributes?: {
+    class?: string | string[];
   };
   single?: boolean;
   singleAttributes?: {
@@ -54,7 +56,7 @@ function setInvalidState(target: FormControl) {
 function setValidationMessage<Data extends Obj>(
   reporterElement: HTMLElement,
   errors: Errors<Data>,
-  { listType = 'ul', listAttributes, single, singleAttributes }: DomReporterOptions
+  { listType = 'ul', listAttributes, listItemAttributes, single, singleAttributes }: DomReporterOptions
 ) {
   const elPath = getPath(reporterElement);
   if (!elPath) return;
@@ -99,7 +101,7 @@ function setValidationMessage<Data extends Obj>(
       messageElement.dataset.felteReporterDomListMessage = '';
       const textNode = document.createTextNode(message);
       messageElement.appendChild(textNode);
-      let classes = listAttributes?.itemClass
+      let classes = listItemAttributes?.class
       if(classes) {
         if (!Array.isArray(classes)) {
           classes = classes.split(' ')

--- a/packages/reporter-dom/src/index.ts
+++ b/packages/reporter-dom/src/index.ts
@@ -8,7 +8,14 @@ import type {
 
 export interface DomReporterOptions {
   listType?: 'ul' | 'ol';
+  listAttributes?: {
+    class?: string | string[];
+    itemClass?: string | string[];
+  };
   single?: boolean;
+  singleAttributes?: {
+    class?: string | string[];
+  };
 }
 
 const mutationConfig: MutationObserverInit = {
@@ -24,7 +31,7 @@ function removeAllChildren(parent: Node): void {
 
 function setValidationMessage(
   target: FormControl,
-  { listType = 'ul', single }: DomReporterOptions
+  { listType = 'ul', listAttributes, single, singleAttributes }: DomReporterOptions
 ) {
   if (!target.name || !target.id) return;
   const validationMessage = target.dataset.felteValidationMessage;
@@ -52,6 +59,13 @@ function setValidationMessage(
     spanElement.dataset.felteReporterDomSingleMessage = '';
     const textNode = document.createTextNode(validationMessage);
     spanElement.appendChild(textNode);
+    let classes = singleAttributes?.class
+    if(classes) {
+      if (!Array.isArray(classes)) {
+        classes = classes.split(' ')
+      }
+      spanElement.classList.add(...classes)
+    }
     reporterElement.appendChild(spanElement);
   }
   if (reportAsList) {
@@ -63,7 +77,21 @@ function setValidationMessage(
       messageElement.dataset.felteReporterDomListMessage = '';
       const textNode = document.createTextNode(message);
       messageElement.appendChild(textNode);
+      let classes = listAttributes?.itemClass
+      if(classes) {
+        if (!Array.isArray(classes)) {
+          classes = classes.split(' ')
+        }
+        listElement.classList.add(...classes)
+      }
       listElement.appendChild(messageElement);
+    }
+    let classes = listAttributes?.class
+    if(classes) {
+      if (!Array.isArray(classes)) {
+        classes = classes.split(' ')
+      }
+      reporterElement.classList.add(...classes)
     }
     reporterElement.appendChild(listElement);
   }


### PR DESCRIPTION
As a [Tailwind CSS](https://tailwindcss.com/) user I always try to declare classes to an element using `class=""` instead of doing by by `<style>` tag. That's important to keep our final bundled CSS file as little as it can be.

Using Felte with `@felte/reporter-dom` I can't declare the classes of the `<span>` created inside the main `<div>`. The only option, [as described in README](https://github.com/pablo-abc/felte/blob/main/packages/reporter-dom/README.md#styling), is using the CSS selector `[data-felte-reporter-dom-single-message]`.

This PR creates the `singleAttributes` and `listAttributes` params that can be used to attach classes to dynamic created elements.

### How to use
```js
extend: [
   reporter({
      single: true,
      singleAttributes: {
         class: ['bg-red-600', 'text-white', 'inline-block', 'py-1', 'px-2', 'rounded'],
      },
      // or, if using `single: false` 
      listAttributes: {
         class: ['list-none', 'bg-red-600', 'text-white', 'block', 'rounded'], // will be applied to main element (`ul` or `ol`)
         itemClass: ['block', 'py-1', 'px-2'], // will be applied to child element (`li`)
      }
   })
],
```

### DOM
```html
<div id="name-validation" data-felte-reporter-dom-for="name">
   <span 
       class="bg-red-600 text-white inline-block py-1 px-2 rounded"
       aria-live="polite"
       data-felte-reporter-dom-single-message=""
   >
      Required field
   </span>
</div>
```
