### PR TITLE
fix(common): fix falsy initial values are ignored

### DIFF
--- a/.changeset/tame-flies-rescue.md
+++ b/.changeset/tame-flies-rescue.md
@@ -1,0 +1,5 @@
+---
+'@felte/common': patch
+---
+
+fix falsy initial values are ignored

--- a/packages/common/src/utils/domUtils.ts
+++ b/packages/common/src/utils/domUtils.ts
@@ -182,7 +182,7 @@ export function setControlValue(
     }
   }
 
-  el.value = String(fieldValue || '');
+  el.value = String(fieldValue ?? '');
 }
 
 /** Sets the form inputs value to match the data object provided. */

--- a/packages/common/tests/utils.test.ts
+++ b/packages/common/tests/utils.test.ts
@@ -101,7 +101,8 @@ function createSignupForm() {
   const firstNameInput = createInputElement({ name: 'firstName' });
   const lastNameInput = createInputElement({ name: 'lastName' });
   const bioInput = createInputElement({ name: 'bio' });
-  profileFieldset.append(firstNameInput, lastNameInput, bioInput);
+  const ageInput = createInputElement({ name: 'age', type: 'number' });
+  profileFieldset.append(firstNameInput, lastNameInput, bioInput, ageInput);
   formElement.appendChild(profileFieldset);
   const pictureInput = createInputElement({
     name: 'profile.picture',
@@ -184,6 +185,7 @@ function createSignupForm() {
     firstNameInput,
     lastNameInput,
     bioInput,
+    ageInput,
     pictureInput,
     extraPicsInput,
     techCheckbox,
@@ -493,6 +495,7 @@ describe('Utils', () => {
         lastName: 'Soplica',
         bio: 'bio',
         picture: undefined,
+        age: 0,
       },
       extra: {
         pictures: [],


### PR DESCRIPTION
This fixes passing falsy value (such as `0`) to the `initialValues` option.

Fixes #36