### PR TITLE
feat(validator-superstruct): support coercion

### DIFF
--- a/.changeset/dull-nails-study.md
+++ b/.changeset/dull-nails-study.md
@@ -1,0 +1,5 @@
+---
+'@felte/validator-superstruct': minor
+---
+
+coerce values before writing to data store if castValues is set.

--- a/.changeset/large-weeks-explain.md
+++ b/.changeset/large-weeks-explain.md
@@ -1,0 +1,5 @@
+---
+'@felte/validator-superstruct': minor
+---
+
+support superstruct coercions

--- a/packages/validator-superstruct/src/index.ts
+++ b/packages/validator-superstruct/src/index.ts
@@ -24,7 +24,7 @@ export function validateStruct<Data extends Obj>(
   }
   return function validate(values: Data): Errors<Data> | undefined {
     try {
-      struct.assert(values);
+      struct.create(values);
     } catch (error) {
       return shapeErrors(error);
     }

--- a/packages/validator-superstruct/src/index.ts
+++ b/packages/validator-superstruct/src/index.ts
@@ -26,7 +26,26 @@ export function validateStruct<Data extends Obj>(
     try {
       struct.create(values);
     } catch (error) {
-      return shapeErrors(error);
+      return shapeErrors(error as StructError);
+    }
+  };
+}
+
+// superstruct does not provide a way to get a coerced value
+// without applying the validation (and possibly throwing)
+// so we catch the error and extract the coerced value
+function coerceStruct(config: ValidatorConfig) {
+  return (values: Obj) => {
+    try {
+      return config.validateStruct.create(values);
+    } catch (error) {
+      return (error as StructError)
+        .failures()
+        .reduce(
+          (obj: Obj, failure: Failure) =>
+            _set(obj, failure.path, failure.value),
+          {}
+        );
     }
   };
 }
@@ -38,11 +57,11 @@ export function createValidator<Data extends Obj = Obj>(
     currentForm: CurrentForm<Data>
   ): ExtenderHandler<Data> {
     if (currentForm.form) return {};
-    const validateFn = validateStruct<Data>(
-      currentForm.config.validateStruct as Struct<any, any>,
-      transform
-    );
-    currentForm.addValidator(validateFn);
+    const config = currentForm.config as CurrentForm<Data>['config'] &
+      ValidatorConfig;
+    currentForm.addValidator(validateStruct(config.validateStruct, transform));
+    if (!config.castValues) return {};
+    currentForm.addTransformer(coerceStruct(config));
     return {};
   };
 }

--- a/packages/validator-superstruct/tests/validator.test.ts
+++ b/packages/validator-superstruct/tests/validator.test.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { createForm } from 'felte';
 import { validateStruct, createValidator } from '../src';
 import type { ValidatorConfig } from '../src';
-import { object, string, size, coerce, date } from 'superstruct';
+import { object, string, size, coerce, date, Infer } from 'superstruct';
 import { get } from 'svelte/store';
 import type { ValidationFunction } from '@felte/common';
 
@@ -304,30 +304,38 @@ describe('Validator superstruct', () => {
       date: coerce(date(), string(), (value) => new Date(value)),
     });
 
-    const mockData = {
+    const { validate, errors, data } = createForm<any, ValidatorConfig>({
+      onSubmit: jest.fn(),
+      extend: createValidator(),
+      validateStruct: struct,
+      castValues: true,
+    });
+
+    data.set({
       name: '',
       date: 'Not A Date',
-    };
-
-    const { validate, errors, data } = createForm({
-      initialValues: mockData,
-      onSubmit: jest.fn(),
-      validate: validateStruct(struct),
     });
+
+    expect(get(data).name).toEqual('');
+    expect(get(data).date).toBeInstanceOf(Date);
+    expect(get(data).date.getTime()).toBeNaN();
 
     await validate();
 
-    expect(get(data)).toEqual(mockData);
     expect(get(errors)).toEqual({
       name:
         'Expected a string with a length between `1` and `Infinity` but received one with a length of `0`',
-        date:
-        'Expected a valid `Date` object, but received: Invalid Date',
+      date: 'Expected a valid `Date` object, but received: Invalid Date',
     });
 
     data.set({
       name: 'test@email.com',
       date: '2021-06-09',
+    });
+
+    expect(get(data)).toEqual({
+      name: 'test@email.com',
+      date: new Date('2021-06-09'),
     });
 
     await validate();


### PR DESCRIPTION
Support coercion, see https://docs.superstructjs.org/api-reference/coercions

You just need to use `create` instead of `assert` to run coercions.