### PR TITLE
docs: remove the "Why" section from the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   - [Svelte](#svelte)
   - [Solid](#solid)
   - [React](#react)
-- [Why](#why)
 - [Packages](#packages)
   - [Svelte](#svelte-1)
     - [`felte`](./packages/felte/README.md)


### PR DESCRIPTION
First, thank you for such a nice form library :tada:
In README, the table of contents has a "Why" section, but the main text does not.