### PR TITLE
refactor: use vanilla custom elements instead of lit

### DIFF
--- a/.changeset/happy-seahorses-suffer.md
+++ b/.changeset/happy-seahorses-suffer.md
@@ -1,0 +1,6 @@
+---
+'@felte/element': patch
+'@felte/reporter-element': patch
+---
+
+Move to vanilla custom elements to reduce bundle size

--- a/README.md
+++ b/README.md
@@ -209,19 +209,19 @@ A reporter packages that uses a Preact component to pass the validation messages
 
 ### VanillaJS
 
-We provide three packages that can be used with only VanillaJS. Two of them using [Web Components](https://www.webcomponents.org/introduction).
+We provide three packages that can be used with only VanillaJS. Two of them using [Web Components](https://www.webcomponents.org/introduction). These elements do not use the shadow DOM since there is no reason to isolate styles.
 
 #### [@felte/element](./packages/element)
 
-This is the main package that contains the basic functionality you need to handle your forms in vanilla JS using a web component. Similar to `felte` but specifically made to be used as a web component. This is the recommended way to handle your forms when using Vanilla JS. Web components are [well supported by all major browsers](https://caniuse.com/custom-elementsv1) so this should be a safe option unless you need to support legacy browsers.
+This is the main package that contains the basic functionality you need to handle your forms in vanilla JS using a custom element. Similar to `felte` but specifically made to be used as a custom element. This is the recommended way to handle your forms when using Vanilla JS. Web components are [well supported by all major browsers](https://caniuse.com/custom-elementsv1) so this should be a safe option unless you need to support legacy browsers.
 
 #### [@felte/reporter-element](./packages/reporter-element)
 
-A reporter packages that uses a web component to display validation messages on the DOM. This the recommended way to display your validation messages when using vanilla JS.
+A reporter packages that uses a custom element to display validation messages on the DOM. This the recommended way to display your validation messages when using vanilla JS.
 
 #### [@felte/vanilla](./packages/vanilla)
 
-This is the main package that contains the basic functionality you need to handle your forms in vanilla JS using a web component. Similar to `felte` and other integrations but with all code related to frameworks removed. This requires a bit more work to use, since you'll be the one in charge of cleaning up subscribers and listeners on it. It's API is basically the same as `felte` (Svelte's integration) so you _can_ use Svelte's documentation as a reference. This can be used as a starting point to create your own integration/package for other environments. When it comes to vanilla JS we'd recommend using `@felte/element` using web components.
+This is the main package that contains the basic functionality you need to handle your forms in vanilla JS. Similar to `felte` and other integrations but with all code related to frameworks removed. This requires a bit more work to use, since you'll be the one in charge of cleaning up subscribers and listeners on it. It's API is basically the same as `felte` (Svelte's integration) so you _can_ use Svelte's documentation as a reference. This can be used as a starting point to create your own integration/package for other environments. When it comes to vanilla JS we'd recommend using `@felte/element` using web components.
 
 ### Validators
 

--- a/examples/lit/basic/index.html
+++ b/examples/lit/basic/index.html
@@ -29,11 +29,6 @@
     </style>
   </head>
   <body>
-    <template id="validation-message">
-      <ul aria-live="polite" part="container">
-        <li part="item" />
-      </ul>
-    </template>
     <sign-in-form></sign-in-form>
   </body>
 </html>

--- a/examples/lit/custom-field/index.html
+++ b/examples/lit/custom-field/index.html
@@ -29,11 +29,6 @@
     </style>
   </head>
   <body>
-    <template id="validation-message">
-      <ul aria-live="polite" part="container">
-        <li part="item" />
-      </ul>
-    </template>
     <sign-in-form></sign-in-form>
   </body>
 </html>

--- a/examples/web-component/cdn/index.html
+++ b/examples/web-component/cdn/index.html
@@ -49,8 +49,8 @@
 
     <!-- template for validation message -->
     <template id="validation-message">
-      <ul aria-live="polite" part="container">
-        <li part="item" />
+      <ul aria-live="polite">
+        <li data-part="item" />
       </ul>
     </template>
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -1,4 +1,4 @@
-# Felte: A form library for vanilla JS (web component)
+# Felte: A form library for vanilla JS (custom element)
 
 [![Tests](https://github.com/pablo-abc/felte/workflows/Tests/badge.svg)](https://github.com/pablo-abc/felte/actions/workflows/test.yml)
 [![Bundle size](https://img.shields.io/bundlephobia/min/@felte/element)](https://bundlephobia.com/result?p=@felte/element)

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -34,8 +34,7 @@
     "uvu": "^0.5.3"
   },
   "dependencies": {
-    "@felte/core": "workspace:*",
-    "lit": "^2.2.0"
+    "@felte/core": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/element/tests/felte-form.spec.ts
+++ b/packages/element/tests/felte-form.spec.ts
@@ -188,4 +188,46 @@ FelteForm('sets configuration using method', async () => {
   });
 });
 
+FelteForm('changes configuration after load', async () => {
+  const onSubmit = sinon.fake();
+  const html = /* HTML */ `
+    <felte-form>
+      <form>
+        <input name="email" />
+        <input name="password" />
+        <button type="submit">Submit</button>
+      </form>
+    </felte-form>
+  `;
+  document.body.innerHTML = html;
+  const felteForm = document.querySelector(
+    'felte-form'
+  ) as HTMLFelteFormElement;
+  expect(felteForm).to.not.be.null;
+  felteForm.setConfiguration({ onSubmit });
+  await waitForReady(felteForm);
+  const button = screen.queryByRole('button', {
+    name: 'Submit',
+  }) as HTMLButtonElement;
+  userEvent.click(button);
+  await waitFor(() => {
+    expect(onSubmit).to.have.been.called.with(
+      {
+        email: '',
+        password: '',
+      },
+      expect.match.any
+    );
+  });
+
+  onSubmit.resetHistory();
+  const altOnSubmit = sinon.fake();
+  felteForm.setConfiguration({ onSubmit: altOnSubmit });
+  userEvent.click(button);
+  await waitFor(() => {
+    expect(onSubmit).to.have.not.been.called;
+    expect(altOnSubmit).to.have.been.called;
+  });
+});
+
 FelteForm.run();

--- a/packages/reporter-element/README.md
+++ b/packages/reporter-element/README.md
@@ -5,7 +5,7 @@
 [![NPM Version](https://img.shields.io/npm/v/@felte/reporter-element)](https://www.npmjs.com/package/@felte/reporter-element)
 [![codecov](https://codecov.io/gh/pablo-abc/felte/branch/main/graph/badge.svg?token=T73OJZ50LC)](https://codecov.io/gh/pablo-abc/felte)
 
-A Felte reporter that uses a web component to report errors.
+A Felte reporter that uses a custom element to report errors.
 
 > **WARNING**: This package is under development, things might break on updates and documentation is almost non-existent besides this README.
 
@@ -30,7 +30,7 @@ The package exports a `reporter` function. Pass the `reporter` function to the `
 * `level`: (optional) the kind of validation messages this element should display. Set it to `warning` to display warning messages. Default: `error`.
 * `templateid` or `templateId`: (optional) the id of the template element to be used for this element.
 
-It expects a `<template>` element as its slot (or assigned using `templateid`), which will be used as the template for your validation messages. This template will be cloned into the shadow DOM and updated when validation messages change. The template **must** have an element with an attribute `part="item"`. This element is the one that will contain the validation message, and it will be appended for each message. Optionally you can add an element with `part="message"` deeper within the item element if you want your message somewhere else.
+It expects a `<template>` element as its child (or assigned using `templateid`), which will be used as the template for your validation messages. This template will be cloned into the as a child of `<felte-validation-message>` and updated when validation messages change. The template **must** have an element with an attribute `data-part="item"`. This element is the one that will contain the validation message, and it will be appended for each message. Optionally you can add an element with `data-part="message"` deeper within the item element if you want your message somewhere else.
 
 An example of its usage:
 
@@ -38,8 +38,8 @@ An example of its usage:
 <felte-validation-message for="email" max="2">
   <template>
     <ul aria-live="polite">
-      <li part="item">
-        <em part="message"></em>
+      <li data-part="item">
+        <em data-part="message"></em>
       </li>
     </ul>
   </template>
@@ -51,8 +51,8 @@ When using `templateid`, this package expects the template to be either on the l
 ```html
 <template id="message-template">
   <ul aria-live="polite">
-    <li part="item">
-      <em part="message"></em>
+    <li data-part="item">
+      <em data-part="message"></em>
     </li>
   </ul>
 </template>
@@ -83,14 +83,14 @@ A more complete example using `@felte/element`:
     <input id="email" type="text" name="email" />
     <felte-validation-message for="email" max="1">
       <template>
-        <span part="message" />
+        <span data-part="message" />
       </template>
     </felte-validation-message>
     <input type="password" name="password" />
     <felte-validation-message for="password">
       <template>
         <ul aria-live="polite">
-          <li part="item" />
+          <li data-part="item" />
         </ul>
       </template>
     </felte-validation-message>
@@ -107,64 +107,13 @@ This reporter can help you display your `warning` messages as well. If you want 
 <felte-validation-message level="warning" for="email">
   <template>
     <ul aria-live="polite">
-      <li part="item">
-        <em part="message"></em>
+      <li data-part="item">
+        <em data-part="message"></em>
       </li>
     </ul>
   </template>
 </felte-validation-message>
 ```
-
-## Styling
-
-Since the contents of your template will be inserted on the shadow DOM, you'll need to use the CSS selector `::part` to style the messages. For example:
-
-```html
-<style>
-  felte-validation-message::part(container) {
-    color: #ff3a43;
-    margin: 0;
-    padding: 0;
-  }
-
-  felte-validation-message::part(item) {
-    list-style: disc inside;
-  }
-</style>
-
-<felte-validation-message level="warning" for="email">
-  <template>
-    <ul aria-live="polite" part="container">
-      <li part="item"></li>
-    </ul>
-  </template>
-</felte-validation-message>
-```
-
-You may also add a `<style>` tag inside of the template:
-
-```html
-<felte-validation-message level="warning" for="email">
-  <template>
-    <style>
-      ul {
-        color: #ff3a43;
-        margin: 0;
-        padding: 0;
-      }
-
-      li {
-        list-style: disc inside;
-      }
-    </style>
-    <ul aria-live="polite" part="container">
-      <li part="item"></li>
-    </ul>
-  </template>
-</felte-validation-message>
-```
-
-You are in control of the contents of the shadow DOM of this element, so you can freely add parts to it for easier styling. The only parts that have "special" meaning are `item` and `message`.
 
 ## Framework compatibility
 

--- a/packages/reporter-element/package.json
+++ b/packages/reporter-element/package.json
@@ -35,8 +35,7 @@
     "uvu": "^0.5.3"
   },
   "dependencies": {
-    "@felte/common": "workspace:*",
-    "lit": "^2.2.0"
+    "@felte/common": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/reporter-element/tests/reporter.spec.ts
+++ b/packages/reporter-element/tests/reporter.spec.ts
@@ -169,16 +169,14 @@ Reporter(
     userEvent.click(formElement);
 
     await waitFor(() => {
-      expect(
-        validationMessageElement.renderRoot.querySelector('ul')
-      ).to.contain.html('<li data-part="item">An error</li>');
-      expect(
-        warningMessageElement.renderRoot.querySelector('ul')
-      ).to.contain.html('<li data-part="item">A warning</li>');
+      expect(validationMessageElement).to.contain.html(
+        '<li data-part="item">An error</li>'
+      );
+      expect(warningMessageElement).to.contain.html(
+        '<li data-part="item">A warning</li>'
+      );
       multipleMessages.forEach((mes) =>
-        expect(mes.renderRoot.querySelector('ul')).to.contain.html(
-          '<li data-part="item">An error</li>'
-        )
+        expect(mes).to.contain.html('<li data-part="item">An error</li>')
       );
     });
 
@@ -255,13 +253,11 @@ Reporter(
     userEvent.click(formElement);
 
     await waitFor(() => {
-      expect(
-        validationMessageElement.renderRoot.querySelector('span')
-      ).to.be.html('<span data-part="item">An error</span>');
+      expect(validationMessageElement).to.be.html(
+        '<span data-part="item">An error</span>'
+      );
       multipleMessages.forEach((mes) => {
-        expect(mes.renderRoot.querySelector('span')).to.contain.html(
-          '<span data-part="item">An error</span>'
-        );
+        expect(mes).to.contain.html('<span data-part="item">An error</span>');
       });
     });
 
@@ -314,9 +310,9 @@ Reporter(
 
     await waitFor(() => {
       expect(inputElement).to.equal(document.activeElement);
-      expect(
-        validationMessageElement.renderRoot.querySelector('span')
-      ).to.have.text.that.contains('A test error');
+      expect(validationMessageElement).to.have.text.that.contains(
+        'A test error'
+      );
     });
   }
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,12 +268,10 @@ importers:
   packages/element:
     specifiers:
       '@felte/core': workspace:*
-      lit: ^2.2.0
       tslib: ^2.3.1
       uvu: ^0.5.3
     dependencies:
       '@felte/core': link:../core
-      lit: 2.2.0
     devDependencies:
       tslib: 2.3.1
       uvu: 0.5.3
@@ -368,12 +366,10 @@ importers:
     specifiers:
       '@felte/common': workspace:*
       '@felte/core': workspace:*
-      lit: ^2.2.0
       tslib: ^2.3.1
       uvu: ^0.5.3
     dependencies:
       '@felte/common': link:../common
-      lit: 2.2.0
     devDependencies:
       '@felte/core': link:../core
       tslib: 2.3.1


### PR DESCRIPTION
Moving to vanilla custom elements to reduce bundle size.
The difference is dramatic specially since our components are really light on logic, so most of the bundle is Lit itself.

## @felte/element

### **With Lit**:

```
./src/index.ts → dist/index.min.js, dist/index.js...
Created bundle index.js: 99.22 kB → 22.31 kB (gzip)
Created bundle index.min.js: 50.44 kB → 15.51 kB (gzip)
created dist/index.min.js, dist/index.js in 5.7s

./src/felte-form.ts → dist/felte-form.min.js, dist/felte-form.js...
Created bundle felte-form.js: 92.29 kB → 20.7 kB (gzip)
Created bundle felte-form.min.js: 47.21 kB → 14.78 kB (gzip)
created dist/felte-form.min.js, dist/felte-form.js in 3.4s

./src/felte-field.ts → dist/felte-field.min.js, dist/felte-field.js...
Created bundle felte-field.js: 27.4 kB → 8.6 kB (gzip)
Created bundle felte-field.min.js: 21.5 kB → 7.62 kB (gzip)
created dist/felte-field.min.js, dist/felte-field.js in 2.3s
```

### **Without Lit**:

```
./src/index.ts → dist/index.min.js, dist/index.js...
Created bundle index.js: 81.76 kB → 15.76 kB (gzip)
Created bundle index.min.js: 32.27 kB → 9.96 kB (gzip)
created dist/index.min.js, dist/index.js in 5.6s

./src/felte-form.ts → dist/felte-form.min.js, dist/felte-form.js...
Created bundle felte-form.js: 73.54 kB → 14.36 kB (gzip)
Created bundle felte-form.min.js: 28.52 kB → 9.04 kB (gzip)
created dist/felte-form.min.js, dist/felte-form.js in 3.4s

./src/felte-field.ts → dist/felte-field.min.js, dist/felte-field.js...
Created bundle felte-field.js: 10.33 kB → 2.35 kB (gzip)
Created bundle felte-field.min.js: 4.34 kB → 1.67 kB (gzip)
created dist/felte-field.min.js, dist/felte-field.js in 1.8s
```

## @felte/reporter-element

### **With Lit**:

```
./src/index.ts → dist/index.min.js, dist/index.js...
Created bundle index.js: 26.49 kB → 8.79 kB (gzip)
Created bundle index.min.js: 22.06 kB → 7.78 kB (gzip)
created dist/index.min.js, dist/index.js in 4.7s
```

### **Without Lit**:

```
./src/index.ts → dist/index.min.js, dist/index.js...
Created bundle index.js: 8.04 kB → 2.34 kB (gzip)
Created bundle index.min.js: 4.14 kB → 1.71 kB (gzip)
created dist/index.min.js, dist/index.js in 4.3s
```