### PR TITLE
fix: small typo in docs

### DIFF
--- a/packages/site/src/markdown/docs/latest/element/en/submitting.md
+++ b/packages/site/src/markdown/docs/latest/element/en/submitting.md
@@ -120,7 +120,7 @@ prepareForm('form-id', {
 });
 ```
 
-* `form` is an HTML form element. This can be useful if you want to send your dara as `FormData`.
+* `form` is an HTML form element. This can be useful if you want to send your data as `FormData`.
 * `controls` is an array containing your HTML elements that refer to your controls.
 * `config` is the original configuration you passed to `createForm`.
 * The rest are some of the same helpers documented in the [helper functions section](/docs/element/helper-functions)

--- a/packages/site/src/markdown/docs/latest/react/en/submitting.md
+++ b/packages/site/src/markdown/docs/latest/react/en/submitting.md
@@ -112,7 +112,7 @@ const { form } = useForm({
 });
 ```
 
-* `form` is an HTML form element. This can be useful if you want to send your dara as `FormData`.
+* `form` is an HTML form element. This can be useful if you want to send your data as `FormData`.
 * `controls` is an array containing your HTML elements that refer to your controls.
 * `config` is the original configuration you passed to `useForm`.
 * The rest are some of the same helpers documented in the [helper functions section](/docs/react/helper-functions)

--- a/packages/site/src/markdown/docs/latest/solid/en/submitting.md
+++ b/packages/site/src/markdown/docs/latest/solid/en/submitting.md
@@ -121,7 +121,7 @@ const { form } = createForm({
 });
 ```
 
-* `form` is an HTML form element. This can be useful if you want to send your dara as `FormData`.
+* `form` is an HTML form element. This can be useful if you want to send your data as `FormData`.
 * `controls` is an array containing your HTML elements that refer to your controls.
 * `config` is the original configuration you passed to `createForm`.
 * The rest are some of the same helpers documented in the [helper functions section](/docs/solid/helper-functions)

--- a/packages/site/src/markdown/docs/latest/svelte/en/submitting.md
+++ b/packages/site/src/markdown/docs/latest/svelte/en/submitting.md
@@ -117,7 +117,7 @@ const { form } = createForm({
 });
 ```
 
-* `form` is an HTML form element. This can be useful if you want to send your dara as `FormData`.
+* `form` is an HTML form element. This can be useful if you want to send your data as `FormData`.
 * `controls` is an array containing your HTML elements that refer to your controls.
 * `config` is the original configuration you passed to `createForm`.
 * The rest are some of the same helpers documented in the [helper functions section](/docs/svelte/helper-functions)


### PR DESCRIPTION
Found a small typo while reading the docs. 