### PR TITLE
fix(common):  don't make _mergeWith choke if one of the inputs is a str

### DIFF
--- a/packages/common/src/utils/mergeWith.ts
+++ b/packages/common/src/utils/mergeWith.ts
@@ -4,12 +4,15 @@ import { _isPlainObject } from './isPlainObject';
 import { deepSet } from './deepSet';
 
 /** @ignore */
-export function _mergeWith<T extends Obj>(...args: any[]): T {
+export function _mergeWith<T>(...args: any[]): T {
   const customizer = args.pop();
-  const obj = _cloneDeep(args.shift());
+  const _obj = args.shift();
+  if (typeof _obj === "string") return _obj as any;
+  const obj = _cloneDeep(_obj);
   if (args.length === 0) return obj;
   for (const source of args) {
     if (!source) continue;
+    if (typeof source === "string") return source as any;
     let rsValue = customizer(obj, source);
     if (typeof rsValue !== 'undefined') return rsValue;
     const keys = Array.from(

--- a/packages/common/tests/utils.spec.ts
+++ b/packages/common/tests/utils.spec.ts
@@ -973,6 +973,8 @@ Utils('mergeErrors', () => {
   ).to.deep.equal({
     test: ['error', 'another'],
   });
+  expect(mergeErrors(["Error" as any, { a: 1 }])).to.equal("Error");
+  expect(mergeErrors([{ a: 1 }, "Error" as any])).to.equal("Error");
 });
 
 Utils('createId', () => {


### PR DESCRIPTION
In case where `data == {a:[{b:0}]}` and `validator == z.object({a:z.any().array().min(2)` the error wìmessage would get mangled and the result of `mergeErrors` would be a object like `{0:'E',1:'r',2:'r',b:[]}` instead of a proper string.This would propagate up and render the error message for the field `a` useless as it would not be a string and its stringification would be useless.