### PR TITLE
fix(common): allow null values in array

### DIFF
--- a/packages/common/src/utils/mapValues.ts
+++ b/packages/common/src/utils/mapValues.ts
@@ -5,7 +5,7 @@ export function _mapValues(
   obj: Obj,
   updater: (value: unknown) => unknown
 ): Obj {
-  const keys = Object.keys(obj);
+  const keys = Object.keys(obj || {});
   return keys.reduce(
     (acc: Obj, key: string) => ({
       ...acc,

--- a/packages/validator-zod/tests/validator.spec.ts
+++ b/packages/validator-zod/tests/validator.spec.ts
@@ -306,4 +306,22 @@ Validator('Issue #116', async () => {
   });
 });
 
+Validator("Allow null input", async () => {
+  const schema = z.object({elems:z.object({ name: z.string() }).optional().array()});
+  const mockData = {elems:[null, { name: "" }]}
+
+  const { validate, errors } = createForm<typeof mockData>({
+    initialValues: mockData,
+    onSubmit: sinon.fake(),
+    extend: validator({ schema }),
+  });
+
+  await validate();
+
+  expect(get(errors)).to.deep.equal({
+    elems:[{0:null},{name:null}]
+  });
+
+})
+
 Validator.run();


### PR DESCRIPTION
Without this it will throw an error in `validate` without reporting in the error store.