### PR TITLE
Handle initial value correctly

### DIFF
--- a/packages/extender-persist/src/index.ts
+++ b/packages/extender-persist/src/index.ts
@@ -38,7 +38,8 @@ export function extender(config: ExtenderConfig) {
     if (!loaded[config.id]) {
       setTimeout(() => {
         const dataString = localStorage.getItem(config.id);
-        const retrievedData = dataString && JSON.parse(dataString);
+        //if previous values does not exists in Local Storage, fallback to the initialValues instead of empty object
+        const retrievedData = (dataString) ? JSON.parse(dataString) : currentForm.config.initialValues;
         currentForm.data.set(retrievedData);
         setForm(form, retrievedData);
         loaded[config.id] = true;

--- a/packages/extender-persist/src/index.ts
+++ b/packages/extender-persist/src/index.ts
@@ -38,10 +38,13 @@ export function extender(config: ExtenderConfig) {
     if (!loaded[config.id]) {
       setTimeout(() => {
         const dataString = localStorage.getItem(config.id);
-        //if previous values does not exists in Local Storage, fallback to the initialValues instead of empty object
-        const retrievedData = (dataString) ? JSON.parse(dataString) : currentForm.config.initialValues;
-        currentForm.data.set(retrievedData);
-        setForm(form, retrievedData);
+
+        if(dataString){
+          const retrievedData = JSON.parse(dataString)
+          currentForm.data.set(retrievedData);
+          setForm(form, retrievedData);
+        }
+
         loaded[config.id] = true;
       });
     }


### PR DESCRIPTION
Right now the extender will set form's value to `{}`, overriding `initialValues` if no item is found in the local storage. This is not a good behavior. This PR is aiming to fix that