### PR TITLE
refactor(reporter-svelte): deprecated svelte component type

### DIFF
--- a/.changeset/rare-toes-rush.md
+++ b/.changeset/rare-toes-rush.md
@@ -1,0 +1,5 @@
+---
+'@felte/reporter-svelte': patch
+---
+
+ValidationMessage component -> move from deprecated SvelteComponentTyped to SvelteComponent type

--- a/packages/reporter-svelte/types/ValidationMessage.d.ts
+++ b/packages/reporter-svelte/types/ValidationMessage.d.ts
@@ -1,11 +1,11 @@
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 
 export interface ValidationMessageProps {
   level?: 'error' | 'warning';
   for: string;
 }
 
-export default class ValidationMessage extends SvelteComponentTyped<
+export default class ValidationMessage extends SvelteComponent<
   ValidationMessageProps,
   Record<string, never>,
   {


### PR DESCRIPTION
Refactor deprecated component type in Svelte 4

https://github.com/sveltejs/svelte/pull/8512

This PR resolves https://github.com/pablo-abc/felte/issues/245