### PR TITLE
Update ValidationMessage types for Svelte 4

### DIFF
--- a/packages/reporter-svelte/types/ValidationMessage.d.ts
+++ b/packages/reporter-svelte/types/ValidationMessage.d.ts
@@ -7,7 +7,7 @@ export interface ValidationMessageProps {
 
 export default class ValidationMessage extends SvelteComponent<
   ValidationMessageProps,
-  Record<string, never>,
+  Record<string, null>,
   {
     default: { messages: string[] | null };
     placeholder: Record<string, never>;


### PR DESCRIPTION
Update ValidationMessage `Events` types to fix type checking in Svelte 4

Fixes https://github.com/pablo-abc/felte/issues/249

