### PR TITLE
fix(solid): delay ref formAction to after mount

### DIFF
--- a/.changeset/fifty-onions-learn.md
+++ b/.changeset/fifty-onions-learn.md
@@ -1,0 +1,5 @@
+---
+'@felte/solid': patch
+---
+
+fix solid initialization from field `value` prop

--- a/packages/solid/tests/create-form.spec.ts
+++ b/packages/solid/tests/create-form.spec.ts
@@ -3,6 +3,7 @@ import { waitFor, screen } from '@testing-library/dom';
 import { createForm, FelteSubmitError } from '../src';
 import { createDOM, cleanupDOM, createInputElement } from './common';
 import { createRoot } from 'solid-js';
+import h from 'solid-js/h';
 
 function createLoginForm() {
   const formElement = screen.getByRole('form') as HTMLFormElement;
@@ -62,6 +63,32 @@ describe('createForm', () => {
     expect(errors()).to.deep.equal({ email: null });
     setErrors({ email: ['not an email'] });
     expect(errors()).to.deep.equal({ email: ['not an email'] });
+  });
+
+  test('sets value with props', async () => {
+    const mockSubmit = vi.fn();
+
+    const expected = { email: 'name@domain.com' };
+
+    const { form, data, createSubmitHandler } = createRoot(() =>
+      createForm({
+        onSubmit: mockSubmit,
+      })
+    );
+
+    createRoot<HTMLFormElement>(
+      h('form', { ref: form }, [
+        h('input', { type: 'email', name: 'email', value: expected.email }),
+      ])
+    );
+
+    expect(data()).toMatchObject(expected);
+
+    const submit = createSubmitHandler();
+    await submit();
+
+    expect(mockSubmit).toHaveBeenCalledOnce();
+    expect(mockSubmit.mock.lastCall[0]).toMatchObject(expected);
   });
 
   test('updates value with helper', () => {


### PR DESCRIPTION
Proposition to fix #195 .

According to Solid documentation https://www.solidjs.com/docs/latest/api#ref:
> Refs are assigned at render time but before the elements are connected to the DOM.

In practice, this means that when the function passed to `ref` is called, elements are created but not attached,  resulting on the `HTMLFormElement` being passed to `formAction` empty with no children.

The documentation indicates the moments the functions are evaluated:
>```ts
>// variable assigned directly by ref
>let myDiv;
>
>// use onMount or createEffect to read after connected to DOM
>onMount(() => console.log(myDiv));
>
><div ref={myDiv} />
>
>// Or, callback function (called before connected to DOM)
><div ref={el => console.log(el)} />
>```

From that and some tests it appear that:
- When `ref` is a pointer, it is accessible in `onMount` or `createEffect` are called **after** it is attached to the DOM.
- When `ref ` is a function, it is called **before** the DOM is attached.
- When `ref` is a function, `onMount` and `createEffect` are first called **before** it is attached to the DOM.

As shown by this trace:
```
onMount - node.childElementCount = undefined
createEffect - node.childElementCount = undefined
ref - node.childElementCount = 0
createEffect - node.childElementCount = 1
```

Which led to my current proposition to proxy the `ref` into a signal observed in an effect. So Felte is initialized onceDOM is ready to be parsed. It does feel hacky though...