### PR TITLE
docs(solid):  Added instructions with the use directive for solid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,29 @@ function Form() {
   });
 
   return (
-    <form use:form>
+    <form use:form={form}>
       <input type="text" name="email" />
       <input type="password" name="password" />
       <button type="submit">Sign In</button>
     </form>
   );
+}
+```
+
+> [!IMPORTANT]
+>
+> To use the `use-*` directive on **Solid**. [You need to extend the JSX namespace](https://docs.solidjs.com/reference/jsx-attributes/use#use). For example:
+
+```dts
+// src/global.d.ts
+declare global {
+  declare module "solid-js" {
+    namespace JSX {
+      interface Directives {
+        form: (node: HTMLFormElement) => void;
+      }
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
There was a weird "gotcha" that took me actually a few frustrating hours to figure out because it wasn't reflected in the docs or anything.

I'm not sure if `use:form` is actually possible because after some experimenting + reading up on how this works: https://docs.solidjs.com/reference/jsx-attributes/use#use.

I still couldn't get it. So I honestly don't know if it's a skill issue or just the docs.

This was the issue I posted yesterday: https://github.com/pablo-abc/felte/issues/291. I think adding this to the readme would save a ton of time.

I found two ways actually:

## Fix 1: Defining in a global dts
```ts
// vite-env.d.ts (or any *.d.ts file)
declare global {
  declare module "solid-js" {
    namespace JSX {
      interface Directives {
        form: (node: HTMLFormElement) => void;
      }
    }
  }
}
```
![image](https://github.com/pablo-abc/felte/assets/38070918/147b87c3-15d4-425a-83b4-62ad8c6dc58a)

## Fix 2: Defining in local file where its used.
```tsx
import { createForm } from "@felte/solid";

declare module "solid-js" {
  namespace JSX {
    interface Directives {
      form: (node: HTMLFormElement) => void;
    }
  }
}
export default function Register() {
  const { form } = createForm({
    onSubmit: async (values) => {
      /** call to an api. */
    },
  });

  return (
    <main class="text-center mx-auto text-gray-700 p-4">
      <h1 class="">Register</h1>

      <form class="form-control" use:form={form}>
      // ...
```

## 🙁 Didn't work
I assumed just using `use:form` would work, but it didn't lol. 

![image](https://github.com/pablo-abc/felte/assets/38070918/69322838-1178-47c5-ab4f-7f3f49057d3d)

## 🙁 Another attempt that didn't work.

This was what the docs showed, and it didn't work. (it's because of the `global` value)
```ts
// vite-env.d.ts (or any *.d.ts file)
declare module "solid-js" {
  namespace JSX {
    interface Directives {
      form: (node: HTMLFormElement) => void;
    }
  }
}
```