### PR TITLE
Update package.json with correct types

### DIFF
--- a/packages/reporter-solid/package.json
+++ b/packages/reporter-solid/package.json
@@ -26,6 +26,7 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "solid": "./dist/source/index.jsx",
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",


### PR DESCRIPTION
Typescript complains about the missing typings, even though it recognizes their location. This fixes that.