### PR TITLE
Support parse params in zod validator

### DIFF
--- a/packages/validator-zod/README.md
+++ b/packages/validator-zod/README.md
@@ -101,3 +101,28 @@ const schema = z.object({
 
 const { form } = createForm<z.infer<typeof schema>>(/* ... */);
 ```
+
+## Error messages
+
+The `validator` function accepts a `params` option that will be forwarded to zod, including [a contextual errorMap](https://zod.dev/ERROR_HANDLING?id=contextual-error-map) used to customize error messages. This parameter can be passed as second argument to the `validateSchema` function.
+
+```javascript
+import { validator } from '@felte/validator-zod';
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().email().nonempty(),
+  password: z.string().nonempty(),
+});
+
+const errorMap: zod.ZodErrorMap = (error) => {
+  // Error messages logic
+  return { message: '' };
+};
+
+const { form } = createForm({
+  // ...
+  extend: validator({ schema }, { errorMap }), // or `validateSchema(schema, { errorMap })`
+  // ...
+});
+```

--- a/packages/validator-zod/src/index.ts
+++ b/packages/validator-zod/src/index.ts
@@ -7,15 +7,17 @@ import type {
   Extender,
 } from '@felte/common';
 import { _update } from '@felte/common';
-import type { ZodError, ZodSchema } from 'zod';
+import type { ParseParams, ZodError, ZodSchema } from 'zod';
 
 export type ValidatorConfig<Data extends Obj = Obj> = {
   schema: ZodSchema<Data>;
   level?: 'error' | 'warning';
+  params?: Partial<ParseParams>;
 };
 
 export function validateSchema<Data extends Obj>(
-  schema: ZodSchema
+  schema: ZodSchema,
+  params?: Partial<ParseParams>
 ): ValidationFunction<Data> {
   function walk(
     error: ZodError,
@@ -45,7 +47,7 @@ export function validateSchema<Data extends Obj>(
   return async function validate(
     values: Data
   ): Promise<AssignableErrors<Data> | undefined> {
-    const result = await schema.safeParseAsync(values);
+    const result = await schema.safeParseAsync(values, params);
     if (!result.success) {
       let err = {} as AssignableErrors<Data>;
       err = walk(result.error, err);
@@ -57,12 +59,13 @@ export function validateSchema<Data extends Obj>(
 export function validator<Data extends Obj = Obj>({
   schema,
   level = 'error',
+  params,
 }: ValidatorConfig): Extender<Data> {
   return function extender(
     currentForm: CurrentForm<Data>
   ): ExtenderHandler<Data> {
     if (currentForm.stage !== 'SETUP') return {};
-    const validateFn = validateSchema<Data>(schema);
+    const validateFn = validateSchema<Data>(schema, params);
     currentForm.addValidator(validateFn, { level });
     return {};
   };

--- a/packages/validator-zod/tests/validator.spec.ts
+++ b/packages/validator-zod/tests/validator.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { expect, describe, test, vi } from 'vitest';
 import { createForm } from './common';
 import { validateSchema, validator } from '../src';
-import { z, ZodSchema } from 'zod';
+import { z, ZodErrorMap, ZodSchema } from 'zod';
 import { get } from 'svelte/store';
 
 type Data = {
@@ -362,5 +362,24 @@ describe('Validator zod', () => {
     const errors = await t(schema, { type: 'baz' });
 
     expect(errors).to.deep.equal({ type: ['Oops'] });
+  });
+
+  test('forwards parse parameters to zod', async () => {
+    const schema = z.object({ foo: z.literal('foo') });
+
+    const errorMap: ZodErrorMap = () => {
+      return { message: 'Oops' };
+    };
+
+    const { validate, errors } = createForm({
+      initialValues: { foo: 'bar' },
+      extend: validator({ schema, params: { errorMap } }),
+    });
+
+    await validate();
+
+    expect(get(errors)).to.deep.equal({
+      foo: ['Oops'],
+    });
   });
 });


### PR DESCRIPTION
Hi,

Zod's `parse` function accepts some parameters, including an `errorMap` that is very useful to translate the error messages (see [this page](https://zod.dev/ERROR_HANDLING?id=contextual-error-map)). I think it would make sense to allow forwarding these parameters from the validator to the parse function.

For example:

```tsx
import { createForm } from '@felte/solid';
import { validateSchema } from '@felte/validator-zod';
import { z } from 'zod';

const schema = z.object({
  description: z.string().min(10),
});

const customErrorMap: z.ZodErrorMap = (error) => {
  // ... error translation logic ...
  return { message: '' };
};

function SomeComponent() {
  const { form } = createForm<z.infer<typeof schema>>({
    validate: validateSchema(schema, {
      errorMap: customErrorMap,
    }),
  });

  return <>...</>;
}
```